### PR TITLE
Fix TOTAL row detection: use CP '* TOTAL' instead of CS 'TOTAL'

### DIFF
--- a/src/zcl_ace_metrics_window.clas.abap
+++ b/src/zcl_ace_metrics_window.clas.abap
@@ -826,7 +826,7 @@ METHOD html_section.
   html_hdr( CHANGING ct_html = ct_html ).
   LOOP AT it_rows INTO DATA(ls_row).
     " CLASS TOTAL / program TOTAL rows get a highlighted style
-    IF ls_row-name CS 'TOTAL'.
+    IF ls_row-name CP '* TOTAL'.
       APPEND '<tr class="tot">' TO ct_html.
       APPEND |<td>{ ls_row-name }</td>| &&
              |<td>{ ls_row-cc }</td><td></td>| TO ct_html.


### PR DESCRIPTION
Prevents methods containing the word TOTAL in their name from being incorrectly highlighted as summary rows.